### PR TITLE
Fix: Remove deprecated domains property from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -104,8 +104,6 @@
 
   "regions": ["sin1", "hkg1", "bom1"],
 
-  "domains": ["beta.bitebase.app"],
-
   "build": {
     "env": {
       "NEXT_PUBLIC_API_URL": "https://api.bitebase.app",


### PR DESCRIPTION
The `domains` property in `vercel.json` is deprecated and caused schema validation errors. Custom domains should be configured in the Vercel project settings dashboard.