### PR TITLE
Fix: Remove regions property from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -102,8 +102,6 @@
     }
   ],
 
-  "regions": ["sin1", "hkg1", "bom1"],
-
   "build": {
     "env": {
       "NEXT_PUBLIC_API_URL": "https://api.bitebase.app",


### PR DESCRIPTION
The current Vercel plan does not support deploying Serverless Functions to multiple regions. This commit removes the `regions` property from `vercel.json` to use the default region (iad1).