### PR TITLE
Refactor: Remove env and build.env from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,23 +7,6 @@
   "installCommand": "npm install",
   "outputDirectory": ".next",
 
-  "env": {
-    "NEXT_PUBLIC_API_URL": "https://api.bitebase.app",
-    "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY": "@next_public_stripe_publishable_key",
-    "NEXT_PUBLIC_FOURSQUARE_CLIENT_ID": "@next_public_foursquare_client_id",
-    "NEXT_PUBLIC_FOURSQUARE_API_KEY": "@next_public_foursquare_api_key",
-    "NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN": "@next_public_mapbox_access_token",
-    "NEXT_PUBLIC_ENABLE_MAPS": "true",
-    "NEXT_PUBLIC_ENABLE_REAL_DATA": "true",
-    "NEXT_PUBLIC_ENABLE_AI_CHAT": "true",
-    "NEXT_PUBLIC_ENVIRONMENT": "production",
-    "NEXT_PUBLIC_APP_NAME": "BiteBase Intelligence",
-    "NEXT_PUBLIC_STACK_PROJECT_ID": "@next_public_stack_project_id",
-    "NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY": "@next_public_stack_publishable_client_key",
-    "STACK_SECRET_SERVER_KEY": "@stack_secret_server_key",
-    "NODE_ENV": "production"
-  },
-
   "functions": {
     "app/api/**/*.js": {
       "maxDuration": 30
@@ -101,24 +84,6 @@
       "permanent": false
     }
   ],
-
-  "build": {
-    "env": {
-      "NEXT_PUBLIC_API_URL": "https://api.bitebase.app",
-      "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY": "@next_public_stripe_publishable_key",
-      "NEXT_PUBLIC_FOURSQUARE_CLIENT_ID": "@next_public_foursquare_client_id",
-      "NEXT_PUBLIC_FOURSQUARE_API_KEY": "@next_public_foursquare_api_key",
-      "NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN": "@next_public_mapbox_access_token",
-      "NEXT_PUBLIC_ENABLE_MAPS": "true",
-      "NEXT_PUBLIC_ENABLE_REAL_DATA": "true",
-      "NEXT_PUBLIC_ENABLE_AI_CHAT": "true",
-      "NEXT_PUBLIC_ENVIRONMENT": "production",
-      "NEXT_PUBLIC_APP_NAME": "BiteBase Intelligence",
-      "NEXT_PUBLIC_STACK_PROJECT_ID": "@next_public_stack_project_id",
-      "NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY": "@next_public_stack_publishable_client_key",
-      "NODE_ENV": "production"
-    }
-  },
 
   "cleanUrls": true,
   "trailingSlash": false


### PR DESCRIPTION
Removed embedded environment variable configurations from `vercel.json`. Environment variables should now be managed manually via the Vercel project dashboard to avoid issues with schema validation and secret management.

This change requires users to configure the following variables in their Vercel project settings:

Runtime Environment Variables:
- NEXT_PUBLIC_API_URL
- NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
- NEXT_PUBLIC_FOURSQUARE_CLIENT_ID
- NEXT_PUBLIC_FOURSQUARE_API_KEY
- NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
- NEXT_PUBLIC_ENABLE_MAPS
- NEXT_PUBLIC_ENABLE_REAL_DATA
- NEXT_PUBLIC_ENABLE_AI_CHAT
- NEXT_PUBLIC_ENVIRONMENT
- NEXT_PUBLIC_APP_NAME
- NEXT_PUBLIC_STACK_PROJECT_ID
- NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY
- STACK_SECRET_SERVER_KEY
- NODE_ENV

Build Environment Variables:
- NEXT_PUBLIC_API_URL
- NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
- NEXT_PUBLIC_FOURSQUARE_CLIENT_ID
- NEXT_PUBLIC_FOURSQUARE_API_KEY
- NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
- NEXT_PUBLIC_ENABLE_MAPS
- NEXT_PUBLIC_ENABLE_REAL_DATA
- NEXT_PUBLIC_ENABLE_AI_CHAT
- NEXT_PUBLIC_ENVIRONMENT
- NEXT_PUBLIC_APP_NAME
- NEXT_PUBLIC_STACK_PROJECT_ID
- NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY
- NODE_ENV